### PR TITLE
Add support for Gopro .360 format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "musicalgestures/gopromax-conversion-tools"]
+	path = musicalgestures/gopromax-conversion-tools
+	url = https://github.com/alexarje/gopromax-conversion-tools.git

--- a/docs/musicalgestures/_360video.md
+++ b/docs/musicalgestures/_360video.md
@@ -9,7 +9,7 @@
 
 ## Mg360Video
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L91)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L94)
 
 ```python
 class Mg360Video(MgVideo):
@@ -30,13 +30,14 @@ Class for 360 videos.
 
 ### Mg360Video().convert_projection
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L123)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L126)
 
 ```python
 def convert_projection(
     target_projection: Union[Projection, str],
     options: Dict[str, str] = None,
     print_cmd: bool = False,
+    test: bool = False,
 ):
 ```
 
@@ -54,7 +55,7 @@ options (Dict[str, str], optional): Options for the conversion. Defaults to None
 
 ## Projection
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L9)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_360video.py#L11)
 
 ```python
 class Projection(Enum):

--- a/docs/musicalgestures/_video.md
+++ b/docs/musicalgestures/_video.md
@@ -79,7 +79,7 @@ Creates an average image of all frames in the video.
 
 ### MgVideo().extract_frame
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L330)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L331)
 
 ```python
 def extract_frame(**kwargs):
@@ -101,7 +101,7 @@ see _utils.extract_frame for details.
 
 ### MgVideo().from_numpy
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L290)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L291)
 
 ```python
 def from_numpy(array, fps, target_name=None):
@@ -119,7 +119,7 @@ Creates a video attribute to the Musical Gestures object with the given correct 
 
 ### MgVideo().numpy
 
-[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L277)
+[[find in source code]](https://github.com/fourMs/MGT-python/blob/master/musicalgestures/_video.py#L278)
 
 ```python
 def numpy():

--- a/musicalgestures/_video.py
+++ b/musicalgestures/_video.py
@@ -230,6 +230,7 @@ class MgVideo(MgAudio):
             ".ts",
             ".wmv",
             ".3gp",
+            ".360",
         ]
         if self.fex not in video_formats:
             # Check if it is an image file

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ README = (HERE / "README.md").read_text()
 setup(
     name='musicalgestures',
     packages=['musicalgestures'],
-    version='v1.3.2',
+    version='v1.3.3',
     license='GNU General Public License v3 (GPLv3)',
     description='Musical Gestures Toolbox for Python',
     long_description=README,


### PR DESCRIPTION
This PR adds support for the special .360 format used by GoPro MAX. By add the submodule made by Alexander (https://github.com/alexarje/gopromax-conversion-tools), the `Mg360Video` is now able to init with `projection="gopro_360"`, and convert it to either equirectangular or dual fisheye format. An example would be:

```python
video = Mg360Video('path/to/video.360', projection="gopro_360")
video.convert_projection(
    target_projection = Projection.equirect, # or Projection.dfisheye
    options={"-r": "0:180:0"}, # optional flags, gives 180 degs of yaw when converting
)
```

After being converted to equirect, it can be further converted to other projections using the previous functions in `Mg360Video` by calling the ffmpeg `vfilter` options.

I've tested the equirect conversion that seems to work well, but there seems to be some issues with the dual fisheye conversion. Nevertheless, I assume the API can be the same and therefore I've included both functionalities. It can be fixed by updating the submodule once the conversion script is fixed.

Another small issue is that the projection conversion is really slow, I got ~x0.15 speed comparing to realtime.

Finally, I wanted to add 360 related contents to the MGT wiki, but it seems like that I need some extra permissions to change the wiki contents. Can anyone help me with that? Thanks in advance :)

Best,
Arthur