### PR TITLE
Stop reusing three variables for two types each

### DIFF
--- a/musicalgestures/_history.py
+++ b/musicalgestures/_history.py
@@ -50,9 +50,9 @@ def history_ffmpeg(self, filename: str | None = None, history_length: int = 10, 
             weights_map += weights
             str_weights = ' '.join([str(weight) for weight in weights_map])
     elif type(weights) == str:
-        weights_as_list = weights.split()
+        weights_as_text = weights.split()
         try:
-            weights_as_list = [float(item) for item in weights_as_list]
+            weights_as_list = [float(item) for item in weights_as_text]
         except ValueError:
             raise MgInputError(
                 'Found wrong type(s) in the list of weights. Use ints and floats.')
@@ -150,10 +150,11 @@ def history_cv2(self, filename: str | None = None, history_length: int = 10, wei
     out = cv2.VideoWriter(target_name, fourcc, fps, (width, height))
 
     ii = 0
-    history = []
+    history: list = []
     weights_map = [1 for weight in range(history_length+1)]
 
     if type(weights) in [int, float]:
+        assert isinstance(weights, (int, float))
         offset = weights - 1
         weights_map[0] = weights
     elif type(weights) == list:

--- a/musicalgestures/_subtract.py
+++ b/musicalgestures/_subtract.py
@@ -107,8 +107,8 @@ def mg_subtract(
         cmd_filter += 'format=gray,smartblur=1,smartblur=3,'
 
     cmd_filter += f'format=gray [mask];[matte][video][mask] maskedmerge, format={pixformat}' 
-    cmd_filter = ['-filter_complex', cmd_filter]  
-    cmd = cmd + cmd_filter + cmd_end
+    filter_flags = ['-filter_complex', cmd_filter]
+    cmd = cmd + filter_flags + cmd_end
 
     ffmpeg_cmd(cmd, get_length(self.filename), pb_prefix='Subtracting background:', stream=True)
 


### PR DESCRIPTION
Continuing the tail of #350. **mypy 50 → 45**, 682 tests pass.

Ordinary inference debt this time rather than hidden failures — which is worth saying, because the earlier batches were not.

- `cmd_filter` in `_subtract` was built as a filter string and then replaced by the two-element flag list carrying it.
- `weights_as_list` in `_history` held the output of `split()` and then the floats parsed from it.
- An unannotated accumulator.
- `type(weights) in [int, float]` decides a branch but does not narrow. Narrowed with an `isinstance` **assert** rather than by rewriting the test: `isinstance` would start accepting `bool`, which `type() in` excludes on purpose, and narrowing for a type checker should not quietly widen what a function takes.

Verified by hand, since these touch real code paths rather than annotations: `subtract()` renders and writes its file, and `history()` works at its default, with string weights, and with a numeric weight.

### Also found, filed separately

While reading this file I confirmed **#370**: `motion_mp()` raises on its first call, and behind that failure calls `save_txt` and `save_analysis` with arguments in the wrong slots. Pre-existing on `master` with a clean tree, not touched here.

Remaining after this: 45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)